### PR TITLE
rustack_vm.ip_address attribute

### DIFF
--- a/rustack_terraform/ports.go
+++ b/rustack_terraform/ports.go
@@ -15,8 +15,12 @@ func (args *Arguments) injectCreatePort() {
 		},
 		"ip_address": {
 			Type:        schema.TypeString,
-			Computed:    true,
+			Optional:    true,
+			Default:     "",
 			Description: "ip_address of the Port",
+			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				return new == ""
+			},
 		},
 		"firewall_templates": {
 			Type:        schema.TypeSet,

--- a/rustack_terraform/resource_rustack_vm.go
+++ b/rustack_terraform/resource_rustack_vm.go
@@ -298,8 +298,13 @@ func createPort(d *schema.ResourceData, manager *rustack.Manager, portPrefix *st
 		}
 		firewalls[j] = portFirewall
 	}
+	ipAddressStr := d.Get(MakePrefix(portPrefix, "ip_address")).(string)
+	ipAddress := &ipAddressStr
+	if ipAddressStr == "" {
+		ipAddress = nil
+	}
 
-	newPort := rustack.NewPort(portNetwork, firewalls, nil)
+	newPort := rustack.NewPort(portNetwork, firewalls, ipAddress)
 	return &newPort, nil
 }
 


### PR DESCRIPTION
**Description**
This is a proposal solution for making the ip_address attribute settable. 
Under the hood, I made ip_address attribute not computed, optional, with an empty string as default value. Next, if the new value is empty string, resource changing will be suppressed. 

Unfortunately, I didn't find any testing framework in the repo, so I wrote no one test. If you have the ability, please, ensure that everything is fine.

**Related Issue**
[#8](
https://github.com/pilat/terraform-provider-rustack/issues/8)