### PR TITLE
v2.3.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.1
 
 require (
-	github.com/basis-cloud/bcc-go v0.5.3
+	github.com/basis-cloud/bcc-go v0.5.6
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.30.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
-github.com/basis-cloud/bcc-go v0.5.3 h1:yRLPncD/AXiBr9kIbE/KAEbCMj6PNIvFW5f996Fh1yc=
-github.com/basis-cloud/bcc-go v0.5.3/go.mod h1:2RJEmbE1nSP33ww3MeysJN7YqNjNsEpvJ3Wwh4T/ljE=
+github.com/basis-cloud/bcc-go v0.5.6 h1:AGqNgNI9nH3pG0VEsHHn754F+uCmoGXXZSGyEP80iag=
+github.com/basis-cloud/bcc-go v0.5.6/go.mod h1:2RJEmbE1nSP33ww3MeysJN7YqNjNsEpvJ3Wwh4T/ljE=
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
update: up version of package bcc-go from 0.5.3 to 0.5.6